### PR TITLE
change download url

### DIFF
--- a/libexec/goenv-install
+++ b/libexec/goenv-install
@@ -50,12 +50,7 @@ if [ "$platform" = "darwin" ]; then
   fi
 fi
 
-# Since go version 1.2, download binary location has been changed to http://golang.org/
-if [ "$version" = "1.2" -o "$version" \> "1.2" ]; then
-  download="https://golang.org/dl/go${version}.${platform}-${arch}${extra}.tar.gz"
-else
-  download="https://go.googlecode.com/files/go${version}.${platform}-${arch}${extra}.tar.gz"
-fi
+download="https://storage.googleapis.com/golang/go${version}.${arch}-${extra}.tar.gz"
 
 # Can't get too clever here
 set +e


### PR DESCRIPTION
Download url is changed

ex) mac

1.2.2 is https://storage.googleapis.com/golang/go1.2.2.darwin-amd64-osx10.8.tar.gz
1.6.3 is https://storage.googleapis.com/golang/go1.6.3.darwin-amd64.tar.gz
1.7rc6 is https://storage.googleapis.com/golang/go1.7rc6.darwin-amd64.tar.gz

---

I checked can install in the mac and CentOS.
